### PR TITLE
Support for the new Switch EIA generation plant dataset

### DIFF
--- a/switch_model/wecc/get_inputs.py
+++ b/switch_model/wecc/get_inputs.py
@@ -419,7 +419,7 @@ def main():
 		select generation_plant_id as hydro_project, 
 			{timeseries_id_select}, 
 			CASE WHEN hydro_min_flow_mw <= 0 THEN 0.01 
-			WHEN hydro_min_flow_mw > capacity_limit_mw THEN capacity_limit_mw
+			WHEN hydro_min_flow_mw > capacity_limit_mw*(1-forced_outage_rate) THEN capacity_limit_mw*(1-forced_outage_rate)
 			ELSE hydro_min_flow_mw END, 
 			CASE WHEN hydro_avg_flow_mw <= 0 THEN 0.01 ELSE
 			least(hydro_avg_flow_mw, (capacity_limit_mw) * (1-forced_outage_rate)) END as hydro_avg_flow_mw


### PR DESCRIPTION
Finally finished uploading and adapting all new (EIA) generation plant data into the DB. These edits to the get_inputs script are meant to properly read the new data and build input sets.

Capacity factors are now read from the new table and not the old AMPL one.
Generator costs are also read from the new table.
Fixed a couple of issues with hydro timeseries.
Fixed a couple of bugs with transmission parameters.

Switch runs and properly solves simple scenarios. You may try with scenario number 8, which has a simple timeset.