### PR TITLE
Fix carbon_cap bug and make more tests pass in Python 3.

### DIFF
--- a/switch_model/policies/carbon_policies.py
+++ b/switch_model/policies/carbon_policies.py
@@ -79,7 +79,8 @@ def post_solve(model, outdir):
                model.carbon_cap_tco2_per_yr[period]]
         # Only print the carbon cap dual value if it exists and if the problem
         # is purely linear.
-        if not model.has_discrete_variables() and model.Enforce_Carbon_Cap[period] in model.dual:
+        if not model.has_discrete_variables() and period in model.Enforce_Carbon_Cap and model.Enforce_Carbon_Cap[
+            period] in model.dual:
             row.append(model.dual[model.Enforce_Carbon_Cap[period]] /
                        model.bring_annual_costs_to_base_year[period])
         else:

--- a/switch_model/policies/rps_by_load_zone.py
+++ b/switch_model/policies/rps_by_load_zone.py
@@ -186,7 +186,7 @@ def post_solve(instance, outdir):
         output_file=os.path.join(outdir, "rps_energy.txt"),
         headings=("LOAD_ZONE", "PERIOD", "RPSFuelEnergyGWh", "RPSNonFuelEnergyGWh",
             "TotalGenerationInPeriodGWh", "RPSGenFraction"),
-        values=lambda m, (z, p): (z, p, m.RPSFuelEnergy[z, p] / 1000,
-                                m.RPSNonFuelEnergy[z, p] / 1000,
-        						total_generation_in_load_zone_in_period(m, z, p) / 1000,
-        						(m.RPSFuelEnergy[z, p] + m.RPSNonFuelEnergy[z, p]) / total_generation_in_load_zone_in_period(m, z, p)))
+        values=lambda m, z_p: (z_p[0], z_p[1], m.RPSFuelEnergy[z_p] / 1000,
+                                m.RPSNonFuelEnergy[z_p] / 1000,
+        						total_generation_in_load_zone_in_period(m, z_p) / 1000,
+        						(m.RPSFuelEnergy[z_p] + m.RPSNonFuelEnergy[z_p]) / total_generation_in_load_zone_in_period(m, z_p)))

--- a/switch_model/reporting/basic_exports_wecc.py
+++ b/switch_model/reporting/basic_exports_wecc.py
@@ -65,7 +65,7 @@ def post_solve(mod, outdir):
     if not os.path.exists(summaries_dir):
         os.makedirs(summaries_dir)
     else:
-        print "Summaries directory exists, clearing it..."
+        print("Summaries directory exists, clearing it...")
         for f in os.listdir(summaries_dir):
             os.unlink(os.path.join(summaries_dir, f))
             
@@ -210,7 +210,7 @@ def post_solve(mod, outdir):
 #            plt.close()
 #        plots.close()
 
-    print "Printing summaries:\n==================="
+    print("Printing summaries:\n===================")
     start=time.time()
 
     # print "renewable energy production"
@@ -256,7 +256,7 @@ def post_solve(mod, outdir):
         index = 'gentech'
         
         table_name = "cummulative_capacity_by_tech_periods"
-        print table_name+" ..."
+        print(table_name + " ...")
         table = export.write_table(
             mod, mod.GENERATION_TECHNOLOGIES,
             output_file=os.path.join(summaries_dir, table_name+".csv"),
@@ -300,7 +300,7 @@ def post_solve(mod, outdir):
 #            return tup
 #
         table_name = "dispatch_tech_periods"
-        print table_name+" ..."
+        print(table_name+" ...")
         table = export.write_table(
             mod, mod.GENERATION_TECHNOLOGIES,
             output_file=os.path.join(summaries_dir, table_name+".csv"),
@@ -328,7 +328,7 @@ def post_solve(mod, outdir):
         index = 'path'
         
         table_name = "cummulative_transmission_by_path_periods"
-        print table_name+" ..."
+        print(table_name+" ...")
         table = export.write_table(
             mod, mod.TRANSMISSION_LINES,
             output_file=os.path.join(summaries_dir, table_name+".csv"),
@@ -338,7 +338,7 @@ def post_solve(mod, outdir):
         ##plot_inv_decision(table_name, table, n_elements, index, True)
         
         table_name = "transmission_installation_by_path_periods"
-        print table_name+" ..."
+        print(table_name+" ...")
         table = export.write_table(
             mod, mod.TRANSMISSION_LINES,
             output_file=os.path.join(summaries_dir, table_name+".csv"),
@@ -382,7 +382,7 @@ def post_solve(mod, outdir):
 #                f.write("    Operational Costs of scenario %s with probability %s: %.2f\n" % (s, mod.scenario_probability[s], calc_tp_costs_in_period_one_scenario(mod, p, s)))
 #  
 #    
-    print "\nTime taken writing summaries: %.2f s." % (time.time()-start)
+    print("\nTime taken writing summaries: %.2f s." % (time.time()-start))
 
 
 

--- a/switch_model/wecc/pyspsolutionwritertemplate.py
+++ b/switch_model/wecc/pyspsolutionwritertemplate.py
@@ -42,7 +42,7 @@ def write_csv_soln(scenario_tree, output_file_prefix):
                               output_file_prefix + ".csv"
                               output_file_prefix + "_StageCostDetail.csv"
     """
-	
+
 #	import ipdb; ipdb.set_trace()
 # josiah's sample code Find the actual syntax/API hooks to use in these next lines
 #	for scenario in scenario_tree.scenarios:
@@ -52,9 +52,9 @@ def write_csv_soln(scenario_tree, output_file_prefix):
 # end of josiah's sample code
 
     if isinstance(scenario_tree, ScenarioTree):
-    	print("Yay.")
-    	for scenario_instance in scenario_tree._scenarios:
-			switch_model.utilities.post_solve(scenario_instance._instance, outputs_dir=os.path.join('outputs', scenario_instance.name))
+        print("Yay.")
+        for scenario_instance in scenario_tree._scenarios:
+            switch_model.utilities.post_solve(scenario_instance._instance, outputs_dir=os.path.join('outputs', scenario_instance.name))
     if not isinstance(scenario_tree, ScenarioTree):
         raise RuntimeError(
             "SwitchSolutionWriter write method expects "


### PR DESCRIPTION
This small PR:

1. Fixes a bug in `policies/carbon_policies.py` where not passing a `carbon_cap_tco2_per_yr` for a period would cause an error, despite the parameter being optional.

2. Lets most tests pass in Python 3 by fixing indentation, print statements and removing lambda tuple expansion.

**Tests completed**

- [x] Verified that not passing `carbon_cap_tco2_per_yr` no longer throws an error.