### PR TITLE
Various bug fixes

### DIFF
--- a/switch_model/balancing/planning_reserves.py
+++ b/switch_model/balancing/planning_reserves.py
@@ -224,7 +224,7 @@ def define_components(model):
             # Note: this code appears to have no users, since it references
             # DispatchGen, which doesn't exist (should be m.DispatchGen).
             if g in getattr(m, 'STORAGE_GENS', set()):
-                reserve_cap += DispatchGen[g, t] - m.ChargeStorage[g, t]
+                reserve_cap += m.DispatchGen[g, t] - m.ChargeStorage[g, t]
             # If local_td is included with DER modeling, avoid allocating
             # distributed generation to central grid capacity because it will
             # be credited with adjusting load at the distribution node.

--- a/switch_model/generators/core/build.py
+++ b/switch_model/generators/core/build.py
@@ -326,17 +326,28 @@ def define_components(mod):
 
 
     def gen_build_can_operate_in_period(m, g, build_year, period):
+        # If a period has the same name as a predetermined build year then we have a problem.
+        # For example, consider what happens if we have both a period named 2020
+        # and a predetermined build in 2020. In this case, "build_year in m.PERIODS"
+        # will be True even if the project is a 2020 predetermined build.
+        # This will result in the "online" variable being the start of the period rather
+        # than the prebuild year which can cause issues such as
+        # the project retiring too soon.
+        #
+        # Our fix is to not use years as IDs for the PERIODS set (e.g. instead we name
+        # our periods IP_2020, IP_2030, etc.). This ensures a predetermined build year will
+        # never be found in m.PERIODS.
+        # TODO: Add a safety check to the model to make sure that no PERIODS have the same name
+        #   as a pre-determined build year.
         if build_year in m.PERIODS:
             online = m.period_start[build_year]
         else:
             online = build_year
         retirement = online + m.gen_max_age[g]
-        return (
-            online <= m.period_start[period] + 0.5 * m.period_length_years[period] < retirement
-        )
-        # This is probably more correct, but is a different behavior
-        # mid_period = m.period_start[period] + 0.5 * m.period_length_years[period]
-        # return online <= m.period_start[period] and mid_period <= retirement
+        # Previously the code read return online <= m.period_start[period] < retirement
+        # However using the midpoint of the period as the "cutoff" seems more correct so
+        # we've made the switch.
+        return online <= m.period_start[period] + 0.5 * m.period_length_years[period] < retirement
 
     # The set of periods when a project built in a certain year will be online
     mod.PERIODS_FOR_GEN_BLD_YR = Set(

--- a/switch_model/generators/extensions/storage.py
+++ b/switch_model/generators/extensions/storage.py
@@ -135,10 +135,13 @@ def define_components(mod):
     # Summarize capital costs of energy storage for the objective function.
     mod.StorageEnergyInstallCosts = Expression(
         mod.PERIODS,
-        rule=lambda m, p: sum(m.BuildStorageEnergy[g, bld_yr] *
-                   m.gen_storage_energy_overnight_cost[g, bld_yr] *
-                   crf(m.interest_rate, m.gen_max_age[g])
-                   for (g, bld_yr) in m.STORAGE_GEN_BLD_YRS))
+        rule=lambda m, p: sum(
+            sum(m.BuildStorageEnergy[g, bld_yr] *
+                m.gen_storage_energy_overnight_cost[g, bld_yr] *
+                crf(m.interest_rate, m.gen_max_age[g])
+                for bld_yr in m.BLD_YRS_FOR_GEN_PERIOD[g, p])
+            for g in m.STORAGE_GENS)
+    )
     mod.Cost_Components_Per_Period.append(
         'StorageEnergyInstallCosts')
 

--- a/switch_model/generators/extensions/storage.py
+++ b/switch_model/generators/extensions/storage.py
@@ -274,6 +274,7 @@ def post_solve(instance, outdir):
     dispatch info to storage_dispatch.csv
     """
     import switch_model.reporting as reporting
+    # Write how much is built each build year for each project to storage_builds.csv
     reporting.write_table(
         instance, instance.STORAGE_GEN_BLD_YRS,
         output_file=os.path.join(outdir, "storage_builds.csv"),
@@ -283,6 +284,7 @@ def post_solve(instance, outdir):
             g, bld_yr, m.gen_load_zone[g],
             m.BuildGen[g, bld_yr], m.BuildStorageEnergy[g, bld_yr],
             ))
+    # Write the total capacity for each project at each period to storage_capacity.csv
     reporting.write_table(
         instance, instance.STORAGE_GEN_PERIODS,
         output_file=os.path.join(outdir, "storage_capacity.csv"),
@@ -292,6 +294,7 @@ def post_solve(instance, outdir):
             g, p, m.gen_load_zone[g],
             m.GenCapacity[g, p], m.StorageEnergyCapacity[g, p])
     )
+    # Write how much is dispatched by each project at each time point to storage_dispatch.csv
     reporting.write_table(
         instance, instance.STORAGE_GEN_TPS,
         output_file=os.path.join(outdir, "storage_dispatch.csv"),

--- a/switch_model/tools/drop.py
+++ b/switch_model/tools/drop.py
@@ -178,7 +178,7 @@ def drop_from_file(filename, foreign_key, valid_ids, args):
     path = os.path.join(args.inputs_dir, filename)
 
     if not os.path.exists(path):
-        return
+        return 0
 
     df = pandas.read_csv(path)
     count = len(df)


### PR DESCRIPTION
## Description
This PR fixes 2 important bugs.

1. Fixes overestimating of costs in the storage module (see https://github.com/switch-model/switch/issues/136).
2. Allows specifying how much predetermined storage should be built via `gen_predetermined_storage_energy_mwh` (see change log for https://github.com/switch-model/switch/blob/next_release/switch_model/generators/extensions/storage.py)

This PR also makes the following minor changes:

- [x] Typo in the planning reserves module.
- [x] Minor fix to `switch drop` tool for the edge case where a file doesn't exist.
- [x] Clarify the bug where prebuild years can conflict with period IDs.
- [x] Note the decision to use the period midpoint as the "cutoff" rather than the period start.
- [x] Clarify what's happening in the storage module post solve.

## What to do after merging

- [x] Add a column to `gen_build_predetermined.csv` named `gen_predetermined_storage_energy_mwh` specifying how much storage should be prebuilt.