### PR TITLE
Remove duplicates from transmission_lines.csv

### DIFF
--- a/switch_model/wecc/get_inputs.py
+++ b/switch_model/wecc/get_inputs.py
@@ -389,7 +389,8 @@ def main():
 					trans_length_km, trans_efficiency, existing_trans_cap_mw 
 					FROM switch.transmission_lines
 					join load_zone as t1 on(t1.load_zone_id=start_load_zone_id)
-					join load_zone as t2 on(t2.load_zone_id=end_load_zone_id)  
+					join load_zone as t2 on(t2.load_zone_id=end_load_zone_id)
+					WHERE start_load_zone_id <= end_load_zone_id 
 					ORDER BY 2,3;
 					"""
     )


### PR DESCRIPTION
This PR ensures that get_inputs doesn't create the transmission lines in both directions.