### PR TITLE
Hotfixes

### DIFF
--- a/switch_model/generators/core/dispatch.py
+++ b/switch_model/generators/core/dispatch.py
@@ -261,7 +261,7 @@ def define_components(mod):
             mod.LOAD_ZONES, mod.TIMEPOINTS,
             rule=lambda m, z, t: \
                 sum(m.DispatchGen[g, t]
-                    for g in m.GENS_IN_ZONE_TPS[z, t] if m.gen_is_distributed[g]),
+                    for g in m.GENS_FOR_ZONE_TPS[z, t] if m.gen_is_distributed[g]),
             doc="Total power from distributed generation projects."
         )
         mod.Distributed_Power_Injections.append('ZoneTotalDistributedDispatch')

--- a/switch_model/transmission/transport/build.py
+++ b/switch_model/transmission/transport/build.py
@@ -181,7 +181,7 @@ def define_components(mod):
     # (e.g., island interconnect scenarios). However, presence of this column will still be
     # checked by load_data_aug.
     mod.min_data_check('trans_lz1', 'trans_lz2')
-    mod.trans_dbid = Param(mod.TRANSMISSION_LINES, default=lambda m, tx: tx)
+    mod.trans_dbid = Param(mod.TRANSMISSION_LINES, default=lambda m, tx: tx, within=Any)
     mod.trans_length_km = Param(mod.TRANSMISSION_LINES, within=NonNegativeReals)
     mod.trans_efficiency = Param(
         mod.TRANSMISSION_LINES,

--- a/switch_model/wecc/get_inputs.py
+++ b/switch_model/wecc/get_inputs.py
@@ -336,6 +336,7 @@ def query_db(full_config, skip_cf):
             ccs_distance_km as zone_ccs_distance_km, 
             load_zone_id as zone_dbid 
         FROM switch.load_zone  
+        WHERE name != '_ALL_ZONES'
         ORDER BY 1;
         """,
     )


### PR DESCRIPTION
Quick fixes to suppress Pyomo warnings and typo in variable name introduced in #50 