### PR TITLE
Add transmission scenarios and drop transmission predetermined costs

### DIFF
--- a/REAM Model Changelog.md
+++ b/REAM Model Changelog.md
@@ -15,6 +15,7 @@ Changes are listed from oldest (first line) to newest (last line of table).
 | ---- | -------------------|
 | #8 | feat: Add support for other types of GHGs (NOx, SO2, CH4) |
 | #12 | fix: use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
+| #15 | fix: Fix bug where storage costs where being over-counted. |
 | #36 | fix: Remove duplicate transmission lines |
 | #10 | feat: Add support for California policies module |
 | #40  | feat: Add support for planning reserves module |

--- a/REAM Model Changelog.md
+++ b/REAM Model Changelog.md
@@ -1,26 +1,18 @@
-# REAM Model Changelog
+# REAM Model Breaking Changes
 
-This file specifies the changes that we have done to the model.
+This file specifies the breaking changes that we have done to the model.
+A breaking change is any change that would change the results of previously
+completed runs.
 
-Pull requests that change the model in a way that will impact our
-results should list their changes here. Pull requests that don't affect our results 
-(e.g. improvements to performance, refactors, workflow, etc.) should not
-update this file.
-
-## Changes to model
+## List of breaking changes to model
 
 Changes are listed from oldest (first line) to newest (last line of table).
 
 | PR | Month | Change description |
 | ---- | --- | ---------------------|
-| #8 | Feb 2021 | feat: Add support for other types of GHGs (NOx, SO2, CH4) |
-| #12 | March 2021 |fix: use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
-| #15 | March 2021 |fix: Fix bug where storage costs where being over-counted. |
-| #36 | May 2021 |fix: Remove duplicate transmission lines |
-| #10 | June 2021 | feat: Add support for California policies module |
-| #40  | June 2021 | feat: Add support for planning reserves module |
-| #50 | June 2021 | Upgraded to Pyomo 6.0 |
-| #56 | June 2021 | fix: Convert 2020 predetermined build years to 2019 in get_inputs to avoid conflicts with 2020 period. |
-| #57 | June 2021 | fix: specify predetermined storage energy capacity (previously left unspecified). |
-| #42 | June 2021| feat: Add parameters to the storage module for self-discharge rate, land use and discharge efficiency. |
-| #68 | June 2021 | fix: change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |
+| #12 | March 2021 | Use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
+| #15 | March 2021 | Fix bug where storage costs where being over-counted. |
+| #36 | May 2021 | Correct inputs to only list transmission lines in one direction. |
+| #56 | June 2021 | Convert 2020 predetermined build years to 2019 in `get_inputs.py` to avoid conflicts with 2020 period. |
+| #57 | June 2021 | Specify predetermined storage energy capacity in inputs (previously left unspecified). |
+| #68 | June 2021 | Change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |

--- a/REAM Model Changelog.md
+++ b/REAM Model Changelog.md
@@ -24,3 +24,4 @@ Changes are listed from oldest (first line) to newest (last line of table).
 | #57 | June 2021 | fix: specify predetermined storage energy capacity (previously left unspecified). |
 | #42 | June 2021| feat: Add parameters to the storage module for self-discharge rate, land use and discharge efficiency. |
 | #68 | June 2021 | fix: change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |
+| #72 | June-July 2021 | fix: drop build and O&M costs of existing transmission lines |

--- a/REAM Model Changelog.md
+++ b/REAM Model Changelog.md
@@ -1,0 +1,25 @@
+# REAM Model Changelog
+
+This file specifies the changes that we have done to the model.
+
+Pull requests that change the model in a way that will impact our
+results should list their changes here. Pull requests that don't affect our results 
+(e.g. improvements to performance, refactors, workflow, etc.) should not
+update this file.
+
+## Changes to model
+
+Changes are listed from oldest (first line) to newest (last line of table).
+
+| PR | Change description |
+| ---- | -------------------|
+| #8 | feat: Add support for other types of GHGs (NOx, SO2, CH4) |
+| #12 | fix: use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
+| #36 | fix: Remove duplicate transmission lines |
+| #10 | feat: Add support for California policies module |
+| #40  | feat: Add support for planning reserves module |
+| #50 | Upgraded to Pyomo 6.0 |
+| #56 | fix: Convert 2020 predetermined build years to 2019 in get_inputs to avoid conflicts with 2020 period. |
+| #57 | fix: specify predetermined storage energy capacity (previously left unspecified). |
+| #42 | feat: Add parameters to the storage module for self-discharge rate, land use and discharge efficiency. |
+| #68 | fix: change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |

--- a/REAM Model Changelog.md
+++ b/REAM Model Changelog.md
@@ -11,16 +11,16 @@ update this file.
 
 Changes are listed from oldest (first line) to newest (last line of table).
 
-| PR | Change description |
-| ---- | -------------------|
-| #8 | feat: Add support for other types of GHGs (NOx, SO2, CH4) |
-| #12 | fix: use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
-| #15 | fix: Fix bug where storage costs where being over-counted. |
-| #36 | fix: Remove duplicate transmission lines |
-| #10 | feat: Add support for California policies module |
-| #40  | feat: Add support for planning reserves module |
-| #50 | Upgraded to Pyomo 6.0 |
-| #56 | fix: Convert 2020 predetermined build years to 2019 in get_inputs to avoid conflicts with 2020 period. |
-| #57 | fix: specify predetermined storage energy capacity (previously left unspecified). |
-| #42 | feat: Add parameters to the storage module for self-discharge rate, land use and discharge efficiency. |
-| #68 | fix: change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |
+| PR | Month | Change description |
+| ---- | --- | ---------------------|
+| #8 | Feb 2021 | feat: Add support for other types of GHGs (NOx, SO2, CH4) |
+| #12 | March 2021 |fix: use the middle of the period instead of the start as the cutoff for retirement and predetermined buildout. |
+| #15 | March 2021 |fix: Fix bug where storage costs where being over-counted. |
+| #36 | May 2021 |fix: Remove duplicate transmission lines |
+| #10 | June 2021 | feat: Add support for California policies module |
+| #40  | June 2021 | feat: Add support for planning reserves module |
+| #50 | June 2021 | Upgraded to Pyomo 6.0 |
+| #56 | June 2021 | fix: Convert 2020 predetermined build years to 2019 in get_inputs to avoid conflicts with 2020 period. |
+| #57 | June 2021 | fix: specify predetermined storage energy capacity (previously left unspecified). |
+| #42 | June 2021| feat: Add parameters to the storage module for self-discharge rate, land use and discharge efficiency. |
+| #68 | June 2021 | fix: change financial params to 2018 dollars & 5% interest rate. Start using terrain multipliers (which now include the economic multiplier). |

--- a/database/2021-06-24_add_transmission_options.sql
+++ b/database/2021-06-24_add_transmission_options.sql
@@ -1,0 +1,19 @@
+/*
+####################
+Add transmission options
+
+Date applied: 2021-06-23
+Description:
+Adds two rows to table transmission_base_capital_cost_scenario_id
+1. A scenario where transmission costs are zero.
+2. A scenario where transmission costs are infinity (building not allowed).
+#################
+*/
+
+INSERT INTO switch.transmission_base_capital_cost (transmission_base_capital_cost_scenario_id,
+                                                   trans_capital_cost_per_mw_km, description)
+VALUES (3, 'Infinity', 'For scenarios where building transmission is forbidden.');
+
+INSERT INTO switch.transmission_base_capital_cost (transmission_base_capital_cost_scenario_id,
+                                                   trans_capital_cost_per_mw_km, description)
+VALUES (4, 0, 'For scenarios where transmission is unlimited.');

--- a/database/2021-06-29_add_transmission_options_v2.sql
+++ b/database/2021-06-29_add_transmission_options_v2.sql
@@ -1,0 +1,13 @@
+/*
+####################
+Add transmission options
+
+Date applied: 2021-06-29
+Description:
+Adds an extra scenario to the database for a 10x increase in transmission costs.
+#################
+*/
+
+INSERT INTO switch.transmission_base_capital_cost (transmission_base_capital_cost_scenario_id,
+                                                   trans_capital_cost_per_mw_km, description)
+VALUES (5, 9600, '10x the costs of scenario #2. Approximates the no TX case.');

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -14,7 +14,9 @@ procedure.
 3. Once your changes are final and ready to be added to the switch main
 branch, create a pull request on Github.
    
-4. Get someone to review and then merge your changes on Github.
+4. If your change is a breaking change add it to `REAM Model Changelog.md`.
+   
+5. Get someone to review and then merge your changes on Github.
 
 For more information read [this excellent guide](https://guides.github.com/introduction/flow/) (5 min read).
 

--- a/switch_model/transmission/transport/build.py
+++ b/switch_model/transmission/transport/build.py
@@ -246,13 +246,13 @@ def define_components(mod):
     # real dollars. The objective function will convert these to
     # base_year Net Present Value in $base_year real dollars.
     mod.TxLineCosts = Expression(
-        mod.TRANS_BLD_YRS,
-        rule=lambda m, tx, p: m.NewTxCapacity[tx, p] * m.trans_cost_annual[tx]
+        mod.TRANSMISSION_LINES, mod.PERIODS,
+        rule=lambda m, tx, p: m.NewTxCapacity[tx, p] * m.trans_cost_annual[tx] if (tx, p) in m.TRANS_BLD_YRS else 0
     )
     mod.TxFixedCosts = Expression(
         mod.PERIODS,
         rule=lambda m, p: sum(
-            m.TxLineCosts[tx, p] for tx in m.TRANSMISSION_LINES if (tx, p) in m.TRANS_BLD_YRS
+            m.TxLineCosts[tx, p] for tx in m.TRANSMISSION_LINES
         )
     )
     mod.Cost_Components_Per_Period.append('TxFixedCosts')

--- a/switch_model/transmission/transport/build.py
+++ b/switch_model/transmission/transport/build.py
@@ -193,18 +193,25 @@ def define_components(mod):
         'trans_length_km', 'trans_efficiency', 'existing_trans_cap')
     mod.trans_new_build_allowed = Param(
         mod.TRANSMISSION_LINES, within=Boolean, default=True)
+    mod.trans_capital_cost_per_mw_km = Param(
+        within=NonNegativeReals,
+        default=1000)
     mod.TRANS_BLD_YRS = Set(
         dimen=2,
         initialize=mod.TRANSMISSION_LINES * mod.PERIODS,
-        filter=lambda m, tx, p: m.trans_new_build_allowed[tx])
+        filter=lambda m, tx, p: m.trans_new_build_allowed[tx] and m.trans_capital_cost_per_mw_km != float("inf"))
     mod.BuildTx = Var(mod.TRANS_BLD_YRS, within=NonNegativeReals)
-    mod.TxCapacityNameplate = Expression(
+    mod.NewTxCapacityNameplate = Expression(
         mod.TRANSMISSION_LINES, mod.PERIODS,
         rule=lambda m, tx, period: sum(
             m.BuildTx[tx, bld_yr]
             for bld_yr in m.PERIODS
             if bld_yr <= period and (tx, bld_yr) in m.TRANS_BLD_YRS
-        ) + m.existing_trans_cap[tx])
+        )
+    )
+    mod.TxCapacityNameplate = Expression(
+        mod.TRANSMISSION_LINES, mod.PERIODS,
+        rule=lambda m, tx, p: m.NewTxCapacityNameplate[tx, p] + m.existing_trans_cap[tx])
     mod.trans_derating_factor = Param(
         mod.TRANSMISSION_LINES,
         within=PercentFraction,
@@ -217,9 +224,6 @@ def define_components(mod):
         mod.TRANSMISSION_LINES,
         within=NonNegativeReals,
         default=1)
-    mod.trans_capital_cost_per_mw_km = Param(
-        within=NonNegativeReals,
-        default=1000)
     mod.trans_lifetime_yrs = Param(
         within=NonNegativeReals,
         default=20)
@@ -244,7 +248,7 @@ def define_components(mod):
     mod.TxFixedCosts = Expression(
         mod.PERIODS,
         rule=lambda m, p: sum(
-            m.TxCapacityNameplate[tx, p] * m.trans_cost_annual[tx]
+            m.NewTxCapacityNameplate[tx, p] * m.trans_cost_annual[tx]
             for tx in m.TRANSMISSION_LINES
         )
     )


### PR DESCRIPTION
This PR:

- ⚠️  Drops the build and O&M costs of existing transmission lines in the model to match the assumption that existing generation and lines are sunk costs. ⚠️ 

- Adds support for infinite transmission line costs (i.e. no transmission can be built).

- Adds 3 transmission scenarios to the database (no cost, infinite cost, 10x cost).

Requires merging #74 first.