### PR TITLE
Small optimizations

### DIFF
--- a/switch_model/energy_sources/fuel_costs/markets.py
+++ b/switch_model/energy_sources/fuel_costs/markets.py
@@ -204,6 +204,10 @@ def define_components(mod):
     become non-linear.
 
     """
+    # When this variable is True we only allow positive fuel costs
+    # This simplifies the model since we can set some of our constraints
+    # as greater than instead of equals.
+    ONLY_POSITIVE_RFM_COSTS = False
 
     mod.REGIONAL_FUEL_MARKETS = Set(dimen=1)
     mod.rfm_fuel = Param(mod.REGIONAL_FUEL_MARKETS, within=mod.FUELS)
@@ -234,7 +238,8 @@ def define_components(mod):
         dimen=3, validate=lambda m, r, p, st: (
             r in m.REGIONAL_FUEL_MARKETS and p in m.PERIODS))
     mod.rfm_supply_tier_cost = Param(
-        mod.RFM_SUPPLY_TIERS, within=Reals)
+        mod.RFM_SUPPLY_TIERS,
+        within=PositiveReals if ONLY_POSITIVE_RFM_COSTS else Reals)
     mod.rfm_supply_tier_limit = Param(
         mod.RFM_SUPPLY_TIERS, within=NonNegativeReals, default=float('inf'))
     mod.min_data_check(
@@ -333,12 +338,16 @@ def define_components(mod):
     enforce_fuel_consumption_scaling_factor = 1e-2
 
     def Enforce_Fuel_Consumption_rule(m, rfm, p):
-        return m.FuelConsumptionInMarket[rfm, p] * enforce_fuel_consumption_scaling_factor \
-               == enforce_fuel_consumption_scaling_factor * sum(
-            m.GenFuelUseRate[g, t, m.rfm_fuel[rfm]] * m.tp_weight_in_year[t]
-            for g in m.GENS_FOR_RFM_PERIOD[rfm, p]
-            for t in m.TPS_IN_PERIOD[p]
-    )
+        lhs = m.FuelConsumptionInMarket[rfm, p] * enforce_fuel_consumption_scaling_factor
+        rhs = enforce_fuel_consumption_scaling_factor * sum(
+            m.GenFuelUseRate[g, t, m.rfm_fuel[rfm]] * m.tp_weight_in_year[t] for g in m.GENS_FOR_RFM_PERIOD[rfm, p] for
+            t in m.TPS_IN_PERIOD[p])
+        # If we have only positive costs, FuelConsumptionInMarket will automatically
+        # try to be minimized in which case we can use a one-sided constraint
+        if ONLY_POSITIVE_RFM_COSTS:
+            return lhs >= rhs
+        else:
+            return lhs == rhs
     mod.Enforce_Fuel_Consumption = Constraint(
         mod.REGIONAL_FUEL_MARKETS, mod.PERIODS,
         rule=Enforce_Fuel_Consumption_rule)

--- a/switch_model/generators/core/dispatch.py
+++ b/switch_model/generators/core/dispatch.py
@@ -233,10 +233,47 @@ def define_components(mod):
     mod.DispatchGen = Var(
         mod.GEN_TPS,
         within=NonNegativeReals)
-    mod.DispatchGenByFuel = Var(mod.GEN_TP_FUELS, within=NonNegativeReals)
+
+    ##########################################
+    # Define DispatchGenByFuel
+    #
+    # Previously DispatchGenByFuel was simply a Variable for all the projects and a constraint ensured
+    # that the sum of DispatchGenByFuel across all fuels was equal the total dispatch for that project.
+    # However this approach creates extra variables in our model for projects that have only one fuel.
+    # Although these extra variables likely get removed during Gurobi pre-solve, we've nonetheless
+    # simplified the model here to reduce time in presolve and ensure the model is always
+    # simplified regardless of the solving method.
+    #
+    # To do this we redefine DispatchGenByFuel to be an
+    # expression that is equal to DispatchGenByFuelVar when we have multiple fuels but
+    # equal to DispatchGen when we have only one fuel.
+
+    # Define a set that is used to define DispatchGenByFuelVar
+    mod.GEN_TP_FUELS_FOR_MULTIFUELS = Set(
+        dimen=3,
+        initialize=mod.GEN_TP_FUELS,
+        filter=lambda m, g, t, f: g in m.MULTIFUEL_GENS,
+        doc="Same as GEN_TP_FUELS but only includes multi-fuel projects"
+    )
+    # DispatchGenByFuelVar is a variable that exists only for multi-fuel projects.
+    mod.DispatchGenByFuelVar = Var(mod.GEN_TP_FUELS_FOR_MULTIFUELS, within=NonNegativeReals)
+    # DispatchGenByFuel_Constraint ensures that the sum of all the fuels is DispatchGen
     mod.DispatchGenByFuel_Constraint = Constraint(
         mod.FUEL_BASED_GEN_TPS,
-        rule=lambda m, g, t: sum(m.DispatchGenByFuel[g, t, f] for f in m.FUELS_FOR_GEN[g]) == m.DispatchGen[g, t])
+        rule=lambda m, g, t:
+        (Constraint.Skip if g not in m.MULTIFUEL_GENS
+         else sum(m.DispatchGenByFuelVar[g, t, f] for f in m.FUELS_FOR_MULTIFUEL_GEN[g]) == m.DispatchGen[g, t])
+    )
+
+    # Define DispatchGenByFuel to equal the matching variable if we have many fuels but to equal
+    # the total dispatch if we have only one fuel.
+    mod.DispatchGenByFuel = Expression(
+        mod.GEN_TP_FUELS,
+        rule=lambda m, g, t, f: m.DispatchGenByFuelVar[g, t, f] if g in m.MULTIFUEL_GENS else m.DispatchGen[g, t]
+    )
+
+    # End Defining DispatchGenByFuel
+    ##########################################
 
     # Only used to improve the performance of calculating ZoneTotalCentralDispatch and ZoneTotalDistributedDispatch
     mod.GENS_FOR_ZONE_TPS = Set(


### PR DESCRIPTION
This PR does two small changes.

- It avoids defining a variable for the dispatch of each fuel if we have only a single fuel.
- It allows using an inequality rather than an equality constraint for the fuel supply curves to improve solving time (in the end this change is disabled since we have fuel curves with 0 costs so we need the equality).