### PR TITLE
Hotfix: catch exceptions during warm starting

### DIFF
--- a/switch_model/tools/graph/main.py
+++ b/switch_model/tools/graph/main.py
@@ -21,29 +21,11 @@ import matplotlib
 import plotnine
 
 # Local imports
-from switch_model.utilities import StepTimer, get_module_list, query_yes_no
+from switch_model.utilities import StepTimer, get_module_list, query_yes_no, catch_exceptions
 
 # When True exceptions that are thrown while graphing will be caught
 # and outputted to console as a warning instead of an error
 CATCH_EXCEPTIONS = True
-
-
-def catch_exceptions(func):
-    """
-    Decorator that wraps a function such that exceptions are caught and outputted as warnings instead.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if not CATCH_EXCEPTIONS:
-            return func(*args, **kwargs)
-        try:
-            return func(*args, **kwargs)
-        except:
-            warnings.warn(f"The following error was caught and we are moving on."
-                          f"{traceback.format_exc()}")
-
-    return wrapper
 
 
 # List of graphing functions. Every time a function uses the @graph() decorator,
@@ -75,7 +57,7 @@ def graph(
 
     def decorator(func):
         @functools.wraps(func)
-        @catch_exceptions
+        @catch_exceptions("Failed to run a graphing function.", should_catch=CATCH_EXCEPTIONS)
         def wrapper(tools: GraphTools):
             if tools.skip_long and is_long:
                 return

--- a/switch_model/utilities/__init__.py
+++ b/switch_model/utilities/__init__.py
@@ -881,7 +881,7 @@ def query_yes_no(question, default="yes"):
                              "(or 'y' or 'n').\n")
 
 
-def catch_exceptions(warning_msg=None, should_catch=True):
+def catch_exceptions(warning_msg="An exception was caught and ignored.", should_catch=True):
     """Decorator that catches exceptions."""
 
     def decorator(func):
@@ -893,8 +893,7 @@ def catch_exceptions(warning_msg=None, should_catch=True):
             try:
                 return func(*args, **kwargs)
             except:
-                if warning_msg is not None:
-                    warnings.warn(warning_msg)
+                warnings.warn(warning_msg + "\nDetailed error log: " + traceback.format_exc())
 
         return wrapper
 

--- a/switch_model/utilities/gurobi_aug.py
+++ b/switch_model/utilities/gurobi_aug.py
@@ -22,7 +22,7 @@ import pickle
 from pyomo.solvers.plugins.solvers.gurobi_direct import GurobiDirect
 from pyomo.environ import *
 
-from switch_model.utilities import StepTimer
+from switch_model.utilities import StepTimer, catch_exceptions
 
 
 class PicklableData:
@@ -206,6 +206,7 @@ class GurobiAugmented(GurobiDirect):
                 print(f"Created warm start pickle file in {timer.step_time_as_str()}")
         return results
 
+    @catch_exceptions(warning_msg="Failed to save warm start information.")
     def _save_warm_start(self, save_c_v_basis):
         """Create a pickle file containing the CBasis/VBasis information."""
         # Setup our data objects


### PR DESCRIPTION
This PR makes sure that any errors that occur while saving the results to `warmstart.pickle` do not interrupt the program. Instead we catch these errors and simply print a warning.