### PR TITLE
Prevent deprecation warning from Pyomo about sorted_robust function

### DIFF
--- a/switch_model/energy_sources/fuel_costs/markets.py
+++ b/switch_model/energy_sources/fuel_costs/markets.py
@@ -366,6 +366,7 @@ def define_components(mod):
         rule=Enforce_Fuel_Consumption_rule)
 
     mod.GEN_TP_FUELS_UNAVAILABLE = Set(
+        dimen=3,
         initialize=mod.GEN_TP_FUELS,
         filter=lambda m, g, t, f: \
             (m.gen_load_zone[g], f) not in m.ZONE_FUELS)

--- a/switch_model/energy_sources/fuel_costs/simple.py
+++ b/switch_model/energy_sources/fuel_costs/simple.py
@@ -61,6 +61,7 @@ def define_components(mod):
     mod.min_data_check('ZONE_FUEL_PERIODS', 'fuel_cost')
 
     mod.GEN_TP_FUELS_UNAVAILABLE = Set(
+        dimen=3,
         initialize=mod.GEN_TP_FUELS,
         filter=lambda m, g, t, f: (
             (m.gen_load_zone[g], f, m.tp_period[t])

--- a/switch_model/generators/core/dispatch.py
+++ b/switch_model/generators/core/dispatch.py
@@ -20,7 +20,9 @@ from __future__ import division
 
 import os, collections
 
-from pyomo.core.base.misc import sorted_robust
+# from pyomo.core.base.misc import sorted_robust
+from pyomo.common.sorting import sorted_robust
+
 from pyomo.environ import *
 import pandas as pd
 

--- a/switch_model/reporting/__init__.py
+++ b/switch_model/reporting/__init__.py
@@ -19,7 +19,7 @@ dependency on load_zones.
 
 """
 from __future__ import print_function
-from pyomo.core.base.misc import sorted_robust
+from pyomo.common.sorting import sorted_robust
 from switch_model.utilities import string_types
 from switch_model.utilities.results_info import add_info
 from switch_model.utilities.scaling import get_unscaled_var


### PR DESCRIPTION
Pyomo 6.1 moved `sorted_robust` from `pyomo.core.base.misc` to `pyomo.common.sorting` and began issuing deprecation warnings for the old location. This imports from the updated location.

This also add dimension to GEN_TP_FUELS_UNAVAILABLE to prevent crash in the post solve.