### PR TITLE
Hold "timeseries" of hydro_timeseries

### DIFF
--- a/switch_model/tools/drop.py
+++ b/switch_model/tools/drop.py
@@ -65,7 +65,6 @@ data_types = {
     "timeseries": (
         ('timeseries.csv', 'TIMESERIES'),
         [
-            ('hydro_timeseries.csv', 'timeseries'),
             ('timepoints.csv', 'timeseries')
         ]
     ),


### PR DESCRIPTION
The "timeseries" column in "hydro_timeseries.csv" is not linked to the TIMESERIES in 'timeseries.csv', but rather is linked to the timepoints through the file hydro_timepoints.csv. If we let the drop tool check the TIMESERIES in  "timeseries" column of hydro_timeseries.csv, then it will always make the file "hydro_timeseries.csv" empty, and as consequence, the hydroplants will dispatch without meeting any hydro constraint. I tested the new drop file under several scenarios for California.