### PR TITLE
Fix bug in --gurobi-make-mps CLI flag and limit to Python <3.11

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -21,7 +21,7 @@
 
 2. Navigate to the repository: `cd switch`.
 
-3. Create a Python virtual environment from where you'll run Switch: `conda create --name switch`.
+3. Create a Python virtual environment from where you'll run Switch: `conda create --name switch python=3.7`.
 
 4. Activate the newly created environment: `conda activate switch`.
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "planning",
         "optimization",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.7,<3.11',
     install_requires=[
         "Pyomo>=6.1,<6.4.1",  # 6.1 Has all the bug fixes we need
         "pint",  # needed by Pyomo when we run our tests, but not included

--- a/switch_model/solve.py
+++ b/switch_model/solve.py
@@ -743,10 +743,10 @@ def solve(model):
         if model.options.gurobi_find_iis:
             # Add to the solver options 'ResultFile=iis.ilp'
             # https://stackoverflow.com/a/51994135/5864903
-            model.options.solver_options_string += " ResultFile=iis.ilp"
+            options_string += " ResultFile=iis.ilp"
         if model.options.gurobi_make_mps:
             # Output the input file and set time limit to zero to ensure it doesn't actually solve
-            model.options.solver_options_string += f" ResultFile=problem.mps TimeLimit=0"
+            options_string += f" ResultFile=problem.mps TimeLimit=0"
 
     if model.options.no_crossover:
         if solver_type in gurobi_types:

--- a/switch_model/tools/drop.py
+++ b/switch_model/tools/drop.py
@@ -76,6 +76,12 @@ data_types = {
             ('hydro_timepoints.csv', 'timepoint_id')
         ]
     ),
+    "hydro_timeseries": (
+        ('hydro_timepoints.csv', 'tp_to_hts'),
+        [
+            ('hydro_timeseries.csv', 'timeseries')
+        ]
+    ),
     "projects": (
         ('generation_projects_info.csv', "GENERATION_PROJECT"),
         [


### PR DESCRIPTION
This PR does do things:

1. I fix a bug that made the command line flags `--gurobi_make_mps` and `--gurobi-find-iis` do nothing (now they work as intended, see `switch solve --help`).
2. I limit the Python version to `<3.11` since Python 3.11 doesn't work with the current version of Pyomo. I also updated the documentation to instruct new users to use Python 3.7 since that is what has been tested.